### PR TITLE
Remove hardcoded sample data from Trends tab

### DIFF
--- a/client/src/Trends.css
+++ b/client/src/Trends.css
@@ -147,3 +147,15 @@
   font-weight: bold;
   color: green;
 }
+
+.trends-empty {
+  padding: 32px;
+  text-align: center;
+  opacity: 0.8;
+}
+.trends-empty h3 {
+  margin: 0 0 8px;
+}
+.trends-empty p {
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- remove hardcoded sample arrays from Trends tab
- handle empty data sets and render a friendly empty state
- add basic styles for the empty state

## Testing
- `npm test --prefix client -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a737f4fdb883319ecd757d12a576c9