### PR TITLE
Enable local data mode and guard API responses

### DIFF
--- a/client/.env.local
+++ b/client/.env.local
@@ -1,0 +1,1 @@
+REACT_APP_DATA_MODE=local

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -19,7 +19,18 @@ export async function apiFetch(url, options = {}) {
   const local = process.env.REACT_APP_DATA_MODE === 'local';
   if (!local) {
     const headers = options.headers ? { ...options.headers } : {};
-    return fetch(url, { ...options, headers });
+    const resp = await fetch(url, { ...options, headers });
+    const ct = resp.headers.get('content-type') || '';
+    if (ct.includes('text/html')) {
+      return {
+        ok: false,
+        json: async () => ({
+          success: false,
+          error: 'Received HTML (is local mode off?)',
+        }),
+      };
+    }
+    return resp;
   }
 
   const method = (options.method || 'GET').toUpperCase();


### PR DESCRIPTION
## Summary
- Force local data mode by supplying `REACT_APP_DATA_MODE=local`
- Guard `apiFetch` against unexpected HTML when not in local mode

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a80667f6448331902108e7b559c96f