### PR TITLE
Add friendly sequential item numbers for inventory

### DIFF
--- a/client/src/InventoryTable.js
+++ b/client/src/InventoryTable.js
@@ -228,9 +228,9 @@ function InventoryTable({ refreshFlag, onInventoryChange }) {
         <table>
           <thead>
             <tr>
-              <th onClick={() => handleSort('id')}>
-                ID
-                {sortConfig.key === 'id' && (
+              <th onClick={() => handleSort('serial')} className="mono">
+                Item #
+                {sortConfig.key === 'serial' && (
                   <span className="sort-indicator">
                     {sortConfig.direction === 'asc' ? '▲' : '▼'}
                   </span>
@@ -310,7 +310,9 @@ function InventoryTable({ refreshFlag, onInventoryChange }) {
                     : ''
                 }
               >
-                <td>{item.id}</td>
+                <td className="mono">
+                  {item.display_id || String(item.serial ?? '').padStart(4, '0')}
+                </td>
                 <td
                   className={`editable-cell ${
                     cellHighlight &&

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -47,3 +47,11 @@ code {
   opacity: 0.8;
   font-size: 0.95rem;
 }
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+td.mono, th.mono {
+  font-variant-numeric: tabular-nums;
+}

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -3,6 +3,9 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { ensureInventorySerials } from './localdb/store';
+
+ensureInventorySerials().catch(() => {});
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
## Summary
- Assign sequential `serial` and padded `display_id` fields to inventory items
- Backfill existing records and maintain a per-device sequence counter
- Show new `Item #` column in inventory table and hide internal UUID

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a80e6ac7a083319a9c461ec9178096